### PR TITLE
Refactor `lib.rs` and add support for environment variable overrides

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,37 @@
+name: Rust
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+
+    - name: Build
+      run: cargo build --verbose
+
+    - name: Run tests
+      run: cargo test --verbose
+
+    - name: Run Clippy
+      run: cargo clippy -- -D warnings
+
+    - name: Run fmt
+      run: cargo fmt --all -- --check

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,6 @@ enum StrategyType {
 }
 
 fn get_dir(target: StrategyType) -> PathBuf {
-
     let target_str = match target {
         StrategyType::Config => "config",
         StrategyType::Cache => "cache",
@@ -122,7 +121,8 @@ fn get_dir(target: StrategyType) -> PathBuf {
         return PathBuf::from(dir);
     }
 
-    let strategy = choose_base_strategy().unwrap_or_else(|_| panic!("Unable to find the {target_str} directory strategy!"));
+    let strategy = choose_base_strategy()
+        .unwrap_or_else(|_| panic!("Unable to find the {target_str} directory strategy!"));
     let mut path = match target {
         StrategyType::Config => strategy.config_dir(),
         StrategyType::Cache => strategy.cache_dir(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ fn get_dir(target: StrategyType) -> PathBuf {
         return PathBuf::from(dir);
     }
 
-    let strategy = choose_base_strategy().expect(format!("Unable to find the {target_str} directory strategy!").as_str());
+    let strategy = choose_base_strategy().unwrap_or_else(|_| panic!("Unable to find the {target_str} directory strategy!"));
     let mut path = match target {
         StrategyType::Config => strategy.config_dir(),
         StrategyType::Cache => strategy.cache_dir(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,7 @@ pub fn merge_toml_values(left: toml::Value, right: toml::Value, merge_depth: usi
             toml_array_value(merge_depth, left_items, right_items)
         }
         (Value::Table(left_map), Value::Table(right_map)) => {
-            toml_table(merge_depth, left_map, right_map)
+            toml_table_value(merge_depth, left_map, right_map)
         }
         // Catch everything else we didn't handle, and use the right value
         (_, value) => value,
@@ -222,7 +222,7 @@ fn toml_array_value(
     Value::Array(left_items)
 }
 
-fn toml_table(
+fn toml_table_value(
     merge_depth: usize,
     mut left_map: Map<String, Value>,
     right_map: Map<String, Value>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,64 @@
+extern crate ignore;
+extern crate git2;
+
+use std::env;
+
+use std::fs::File;
+use std::io;
+
+use git2::Repository;
+use ignore::WalkBuilder;
+
+pub fn get_git_repo_root() -> Option<String> {
+    let current_dir = env::current_dir().ok()?;
+
+    let repo = Repository::discover(&current_dir).ok()?;
+    let repo_root = repo.workdir()?.to_string_lossy().to_string();
+
+    Some(repo_root)
+}
+
+pub fn list_available_files(repo_path: &str) -> io::Result<()> {
+    let walker = WalkBuilder::new(repo_path)
+        .hidden(true)
+        .git_ignore(true)
+        .parents(false)
+        .build();
+
+    // Traverse the directory with gitignore rules applied
+    for entry in walker {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(err) => return Err(io::Error::new(io::ErrorKind::Other, err)),
+        };
+
+        // Skip directories
+        if entry.file_type().expect(".").is_dir() {
+            continue;
+        }
+
+        // Open each file and process it
+        if let Ok(_file) = File::open(entry.path()) {
+            println!("File: {:?}", entry.path());
+            // Read the file line by line
+            // let reader = io::BufReader::new(file);
+            // for line in reader.lines() {
+            //     if let Ok(line) = line {
+            //         // Process each line as needed
+            //         println!("{}", line);
+            //     }
+            // }
+        }
+    }
+
+    Ok(())
+}
+
 fn main() {
-    println!("Hello, world!");
+    if let Some(repo_root) = get_git_repo_root() {
+        let _ = list_available_files(&repo_root);
+        println!("Git repository root: {}", repo_root);
+    } else {
+        println!("Not inside a Git repository.");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 
-use balpan::utils::{get_git_repo_root, list_available_files};
 use balpan::grammar::fetch_grammars;
+use balpan::utils::{get_git_repo_root, list_available_files};
 
 fn main() -> Result<()> {
     if let Some(repo_root) = get_git_repo_root() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,7 +9,7 @@ use ignore::WalkBuilder;
 pub fn get_git_repo_root() -> Option<String> {
     let current_dir = env::current_dir().ok()?;
 
-    let repo = Repository::discover(&current_dir).ok()?;
+    let repo = Repository::discover(current_dir).ok()?;
     let repo_root = repo.workdir()?.to_string_lossy().to_string();
 
     Some(repo_root)


### PR DESCRIPTION
## Description

 - Refactor the code to eliminate duplication in the `config_dir` and `cache_dir` methods and add support for environment variable overrides.

 - Decoupled the functionality of the `merge_toml_values` function to reduce its size

### Changes

 - **Refactor `merge_toml_values`** : To reduce the size of the existing `merge_toml_values` function and improve readability, we have split it into two methods, `toml_array_value` and `toml_table_value`.

 - **Refactor Directory Retrieval** : To eliminate code duplication, a helper function `get_dir` has been introduced which now accepts an `enum StrategyType`. This change reduces duplication and increases the code's robustness, I guess. The function `get_dir` first checks for an override environment variable before using the default strategy.

 - **Environment Variable Overrides** : The `get_dir` method supports directory override through environment variables, following the convention <DIR_TYPE>_DIR_OVERRIDE. If an override variable is set, the function will return the overridden path. If not, the function will fall back to the original logic and retrieve the directory path using the `choose_base_strategy`. I don't know if this is correct, though, so I've added a test for this implementation.