### PR TITLE
Implement `Scanner` struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 // https://github.com/helix-editor/helix/blob/master/helix-loader/src/lib.rs 
 pub mod config;
 pub mod grammar;
+pub mod scanner;
 pub mod utils;
 pub mod tree_sitter_extended;
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1,0 +1,61 @@
+use std::cell::{RefCell,Ref};
+
+use tree_sitter::{Tree, Parser, Node};
+
+use crate::grammar::get_language;
+
+pub struct Scanner {
+    pub source_code: String
+}
+
+pub trait Traversable<'a, 'b> {
+    fn scan(&'b self);
+    fn get_syntax_tree(&'b self) -> Tree;
+    fn get_top_level_nodes(&'a self, tree: &'b Tree) -> Vec<Node<'b>>;
+}
+
+impl<'a, 'b> Traversable<'a, 'b> for Scanner {
+    fn get_syntax_tree(&'b self) -> Tree {
+        let parser = RefCell::new(Parser::new());
+        let language = get_language("rust").unwrap();
+
+        let mut ts_parser = parser.borrow_mut();
+        match ts_parser.set_language(language) {
+            Ok(_) => (),
+            Err(_) => panic!("treesitter parser for given language does not exists")
+        }
+
+        let tree: Option<Tree> = ts_parser.parse(<String as AsRef<str>>::as_ref(&self.source_code.to_string()), None);
+        match tree {
+            Some(tree) => {
+                return tree
+            }
+            None => panic!("Failed to parsing given source code")
+        }
+    } 
+
+    fn scan(&'b self) {
+        let tree = self.get_syntax_tree();
+        let nodes = self.get_top_level_nodes(
+            &tree
+        );
+    }
+
+    fn get_top_level_nodes(
+        &'a self, 
+        cloned_tree: &'b Tree
+    ) -> Vec<Node<'b>> {
+        {
+            let node = cloned_tree.root_node();
+            let mut cursor = node.walk();
+
+            return node
+                .children(&mut cursor)
+                .map( |child_node| {
+                    child_node
+                })
+                .collect()
+
+        }
+    }
+}

--- a/tests/scanner_test.rs
+++ b/tests/scanner_test.rs
@@ -1,0 +1,4 @@
+#[cfg(test)]
+mod scanner_test {
+    mod get_top_level_nodes_test;
+}

--- a/tests/scanner_test/get_top_level_nodes_test.rs
+++ b/tests/scanner_test/get_top_level_nodes_test.rs
@@ -1,0 +1,81 @@
+#[cfg(test)]
+mod get_top_level_nodes_test {
+    use balpan::scanner::{Scanner,Traversable};
+    use balpan::grammar::{fetch_grammars, build_grammars};
+
+    fn assert_top_level_node_kinds(source_code: &str, expected: Vec<&str>) {
+        fetch_grammars();
+        build_grammars(None);
+
+        let scanner = Scanner { 
+            source_code: source_code.to_string() 
+        };
+
+        let tree = scanner.get_syntax_tree();
+        let nodes = scanner.get_top_level_nodes(&tree);
+
+        let result: Vec<&str> = nodes
+            .iter()
+            .map( |node| { node.kind() } )
+            .collect();
+
+        assert!(
+            expected.iter().eq(
+                result.iter()
+            )
+        );
+    }
+
+    #[test]
+    fn test_declaring_error_enum_with_macro() {
+        let source_code = r#"
+        use thiserror::Error;
+
+        #[derive(Error, Debug)]
+        pub enum FormatError {
+            #[error("Invalid header (expected {expected:?}, got {found:?})")]
+            InvalidHeader {
+                expected: String,
+                found: String,
+            },
+            #[error("Missing attribute: {0}")]
+            MissingAttribute(String),
+        }
+        "#;
+
+        let expected = vec!["use_declaration", "attribute_item", "enum_item"];
+
+        assert_top_level_node_kinds(source_code, expected);
+    }
+
+    #[test]
+    fn test_macro_invocation_statement() {
+        let source_code = r#"
+        use target_spec::eval;
+
+        // Evaluate Rust-like `#[cfg]` syntax.
+        let cfg_target = "cfg(all(unix, target_arch = \"x86_64\"))";
+        assert_eq!(eval(cfg_target, "x86_64-unknown-linux-gnu").unwrap(), Some(true));
+        assert_eq!(eval(cfg_target, "i686-unknown-linux-gnu").unwrap(), Some(false));
+        assert_eq!(eval(cfg_target, "x86_64-pc-windows-msvc").unwrap(), Some(false));
+
+        // Evaluate a full target-triple.
+        assert_eq!(eval("x86_64-unknown-linux-gnu", "x86_64-unknown-linux-gnu").unwrap(), Some(true));
+        assert_eq!(eval("x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc").unwrap(), Some(false));    
+        "#;
+
+        let expected = vec![
+            "use_declaration",
+            "line_comment",
+            "let_declaration",
+            "expression_statement",
+            "expression_statement",
+            "expression_statement",
+            "line_comment",
+            "expression_statement",
+            "expression_statement",
+        ];
+
+        assert_top_level_node_kinds(source_code, expected)
+    }
+}


### PR DESCRIPTION
related to #6 

The `Scanner` struct scans whole of the source code.
And this builds syntax tree from the source code using tree-sitter parser.

Through building syntax tree, we can extract top level nodes of the syntax tree.
And we can use it as hint for where to insert `TODO comment`
