### PR TITLE
Split `MembershipCheck`'s `is_member_of` method into three components

### DIFF
--- a/src/tree_sitter_extended.rs
+++ b/src/tree_sitter_extended.rs
@@ -2,23 +2,46 @@ use tree_sitter::{Point, Range};
 
 
 pub trait MembershipCheck {
+    fn is_before(&self, range: Range) -> bool;
+    fn is_after(&self, range: Range) -> bool;
     fn is_member_of(&self, range: Range) -> bool;
 }
 
 impl MembershipCheck for Point {
-    fn is_member_of(&self, range: Range) -> bool {
+    fn is_before(&self, range: Range) -> bool {
         let start_point = range.start_point;
+
+        if self.row < start_point.row {
+            return true;
+        }
+
+        if self.row > start_point.row {
+            return false;
+        }
+
+        self.column < start_point.column
+    }
+
+    fn is_after(&self, range: Range) -> bool {
         let end_point = range.end_point;
 
-        if self.row < start_point.row || self.row > end_point.row {
+        if self.row < end_point.row {
             return false;
         }
 
-        if self.row == start_point.row && self.column < start_point.column {
+        if self.row > end_point.row {
+            return true;
+        }
+
+        self.column > end_point.column
+    }
+
+    fn is_member_of(&self, range: Range) -> bool {
+        if self.is_before(range) {
             return false;
         }
 
-        if self.row == end_point.row && self.column > end_point.column {
+        if self.is_after(range) {
             return false;
         }
 

--- a/tests/tree_sitter_extended_test.rs
+++ b/tests/tree_sitter_extended_test.rs
@@ -23,6 +23,7 @@ mod tree_sitter_extended_tests {
             }
         };
 
+        assert!(cursor.is_before(function_scope));
         assert!(!cursor.is_member_of(function_scope));
     }
 
@@ -74,8 +75,10 @@ mod tree_sitter_extended_tests {
             }
         };
 
+        assert!(!cursor_with_pointing_start.is_before(function_scope));
         assert!(cursor_with_pointing_start.is_member_of(function_scope));
         assert!(cursor_with_pointing_end.is_member_of(function_scope));
+        assert!(!cursor_with_pointing_end.is_after(function_scope));
     }
 
     #[test]
@@ -103,7 +106,9 @@ mod tree_sitter_extended_tests {
             }
         };
 
+        assert!(left_of_start_point.is_before(function_scope));
         assert!(!left_of_start_point.is_member_of(function_scope));
         assert!(!right_of_end_point.is_member_of(function_scope));
+        assert!(right_of_end_point.is_after(function_scope));
     }
 }


### PR DESCRIPTION
related to #2

1) Add a bit improvement in readability.

2) In order to scan whole of the source code,
   we need to iterate over the array of tree-sitter nodes
   which could be returned via `Scanner`'s `get_top_level_nodes` method

  * Whenever reading each line of the source code,
    we have to determine whether TODO comment line should be inserted or not.

  * Because of this consideration,
    We have to manage two queue or deques.
    - `writing_buffer` : this can be used for overwriting source code
    - `nodes` : the array of tree-sitter nodes