### PR TITLE
Add test for ignorable insert annotation attributes

### DIFF
--- a/tests/analyzer_test/analyze_test.rs
+++ b/tests/analyzer_test/analyze_test.rs
@@ -115,6 +115,7 @@ mod analyze_test {
     }
 
     #[test]
+    #[ignore]
     fn test_ignore_doc_macro() {
         let source_code = indoc! {"
             #[doc = \"This is a doc comment\"]

--- a/tests/analyzer_test/analyze_test.rs
+++ b/tests/analyzer_test/analyze_test.rs
@@ -6,8 +6,8 @@ mod analyze_test {
     use balpan::grammar::{fetch_grammars, build_grammars};
 
     fn assert_analyzed_source_code(source_code: &str, expected: &str) {
-        fetch_grammars();
-        build_grammars(None);
+        fetch_grammars().unwrap();
+        build_grammars(None).unwrap();
 
         let analyzer = Analyzer {
             source_code: source_code.to_string()
@@ -60,6 +60,73 @@ mod analyze_test {
             #[error(\"Missing attribute: {0}\")]
             MissingAttribute(String),
         }"};
+
+        assert_analyzed_source_code(source_code, result)
+    }
+
+    #[test]
+    fn test_stacked_macros() {
+        let source_code = indoc! {"
+            #[derive(Deserialize)]
+            #[serde(bound(deserialize = \"T: Deserialize<'de>\"))]
+            struct List<T> {
+                #[serde(deserialize_with = \"deserialize_vec\")]
+                items: Vec<T>,
+            }"};
+
+        let result = indoc! {"
+            /// [TODO]
+            #[derive(Deserialize)]
+            #[serde(bound(deserialize = \"T: Deserialize<'de>\"))]
+            struct List<T> {
+                #[serde(deserialize_with = \"deserialize_vec\")]
+                items: Vec<T>,
+            }"};
+
+        assert_analyzed_source_code(source_code, result)
+    }
+
+    #[test]
+    #[ignore]
+    fn test_ignore_todo_test_macro() {
+        let source_code = indoc! {"
+            #[cfg(test)]
+            mod tests {
+                use super::*;
+
+                #[test]
+                fn test_foo() {
+                    assert_eq!(foo(), 1);
+                }
+            }"};
+
+        let result = indoc! {"
+            #[cfg(test)]
+            mod tests {
+                use super::*;
+
+                #[test]
+                fn test_foo() {
+                    assert_eq!(foo(), 1);
+                }
+            }"};
+
+        assert_analyzed_source_code(source_code, result)
+    }
+
+    #[test]
+    fn test_ignore_doc_macro() {
+        let source_code = indoc! {"
+            #[doc = \"This is a doc comment\"]
+            fn foo() {
+                println!(\"foo\");
+            }"};
+
+        let result = indoc! {"
+            #[doc = \"This is a doc comment\"]
+            fn foo() {
+                println!(\"foo\");
+            }"};
 
         assert_analyzed_source_code(source_code, result)
     }

--- a/tests/analyzer_test/get_top_level_nodes_test.rs
+++ b/tests/analyzer_test/get_top_level_nodes_test.rs
@@ -4,8 +4,8 @@ mod get_top_level_nodes_test {
     use balpan::grammar::{fetch_grammars, build_grammars};
 
     fn assert_top_level_node_kinds(source_code: &str, expected: Vec<&str>) {
-        fetch_grammars();
-        build_grammars(None);
+        fetch_grammars().unwrap();
+        build_grammars(None).unwrap();
 
         let analyzer = Analyzer { 
             source_code: source_code.to_string() 


### PR DESCRIPTION
In my opinion, cases like `#[doc]` or `#[test]` shouldn't need to be annotated, so it would be nice to exclude them from node traversal.
I'm guessing that pulling the metadata from this part would work, but I don't know.

https://github.com/balpan-rs/balpan/blob/main/src/analyzer.rs#L95

I tried to do it this way and failed, but I'm attaching it for reference.

```rust
if node_type == &"attribute_item" {
    if let Some(meta_item) = current_node.child(0) {
        if let Some(identifier) = meta_item.child(0) {
            let identifier_name = identifier.utf8_text(&self.source_code.as_bytes()).unwrap();

            // if identifier name is "doc" or "cfg", then we should skip this line
            // ...
        }
    }
    pending_queue.push_back(line);
}
```