### PR TITLE
Improve code stability of `Analyzer`

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -6,9 +6,36 @@ use tree_sitter::{Node, Parser, Point, Range, Tree};
 use crate::grammar::get_language;
 use crate::tree_sitter_extended::{MembershipCheck, RangeFactory};
 
+/// Language enum for `Analyzer` struct
+pub enum Language {
+    Rust,
+    Python,
+    Other,
+}
+
+impl Language {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::Rust => "rust",
+            Self::Python => "python",
+            _ => "",
+        }
+    }
+}
+
+impl From<&str> for Language{
+    fn from(language_name: &str) -> Self {
+        match language_name {
+            "rust" => Self::Rust,
+            "python" => Self::Python,
+            _ => Self::Other,
+        }
+    }
+}
+
 pub struct Analyzer {
     pub source_code: String,
-    pub language: String,
+    pub language: Language,
 }
 
 pub trait Traversable<'tree> {
@@ -24,26 +51,24 @@ pub trait Traversable<'tree> {
 
 impl<'tree> Traversable<'tree> for Analyzer {
     fn top_level_node_type(&self) -> &str {
-        match self.language.as_str() {
-            "rust" => "source_file",
-            "python" => "module",
-            _ => ""
+        match self.language {
+            Language::Rust => "source_file",
+            Language::Python => "module",
+            _ => "",
         }
     }
 
     fn decorator_node_type(&self) -> &str {
-        match self.language.as_str() {
-            "rust" => "attribute_item",
-            "python" => "null",
+        match self.language {
+            Language::Rust => "attribute_item",
+            Language::Python => "null",
             _ => "",
         }
     }
 
     fn get_annotation_whitelist(&self) -> Vec<&str> {
-        let language = self.language.as_str();
-
-        match language {
-            "rust" => vec![
+        match self.language {
+            Language::Rust => vec![
                 "attribute_item",
                 "mod_item",
                 "enum_item",
@@ -54,7 +79,7 @@ impl<'tree> Traversable<'tree> for Analyzer {
                 "trait_item",
                 "macro_definition",
             ],
-            "python" => vec![
+            Language::Python => vec![
                 "class_definition",
                 "function_definition",
                 "decorated_definition",
@@ -64,10 +89,10 @@ impl<'tree> Traversable<'tree> for Analyzer {
     }
 
     fn get_indent_comment_pool(&self) -> Vec<String> {
-        let comment = match self.language.as_str() {
-            "rust" => "/// [TODO]",
-            "python" => "# [TODO]",
-            _ => "//"
+        let comment = match self.language {
+            Language::Rust => "/// [TODO]",
+            Language::Python => "# [TODO]",
+            _ => "//",
         };
         let ident = "    ";
         let max_ident_level = 8;
@@ -81,15 +106,12 @@ impl<'tree> Traversable<'tree> for Analyzer {
     }
 
     fn get_nested_traversable_symbols(&self) -> Vec<&str> {
-        let language = self.language.as_str();
-
-        match language {
-            "rust" => vec!["mod_item", "impl_item"],
-            "python" => vec![
-                "class_definition",
-            ],
-            _ => vec![]
+        match self.language {
+            Language::Rust => vec!["mod_item", "impl_item"],
+            Language::Python => vec!["class_definition"],
+            _ => vec![],
         }
+
     }
 
     fn get_syntax_tree(&self) -> Tree {
@@ -205,7 +227,9 @@ impl<'tree> Traversable<'tree> for Analyzer {
                     result.push(node);
                 }
 
-                if !nested_traversable_symbols.contains(&node_type) && node_type != self.top_level_node_type() {
+                if !nested_traversable_symbols.contains(&node_type)
+                    && node_type != self.top_level_node_type()
+                {
                     continue;
                 }
 

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -5,33 +5,7 @@ use tree_sitter::{Node, Parser, Point, Range, Tree};
 
 use crate::grammar::get_language;
 use crate::tree_sitter_extended::{MembershipCheck, RangeFactory};
-
-/// Language enum for `Analyzer` struct
-pub enum Language {
-    Rust,
-    Python,
-    Other,
-}
-
-impl Language {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::Rust => "rust",
-            Self::Python => "python",
-            _ => "",
-        }
-    }
-}
-
-impl From<&str> for Language{
-    fn from(language_name: &str) -> Self {
-        match language_name {
-            "rust" => Self::Rust,
-            "python" => Self::Python,
-            _ => Self::Other,
-        }
-    }
-}
+use crate::language::Language;
 
 pub struct Analyzer {
     pub source_code: String,

--- a/src/language.rs
+++ b/src/language.rs
@@ -1,0 +1,26 @@
+
+pub enum Language{
+    Rust,
+    Python,
+    Other(String),
+}
+
+impl Language {
+  pub fn as_str(&self) -> &str {
+      match self {
+          Self::Rust => "rust",
+          Self::Python => "python",
+          Self::Other(language) => language.as_str(),
+      }
+  }
+}
+
+impl From<&str> for Language{
+  fn from(language_name: &str) -> Self {
+      match language_name {
+          "rust" => Self::Rust,
+          "python" => Self::Python,
+          other_language => Self::Other(other_language.to_string()),
+      }
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod grammar;
 pub mod analyzer;
 pub mod utils;
 pub mod tree_sitter_extended;
+pub mod language;
 
 use etcetera::base_strategy::{choose_base_strategy, BaseStrategy};
 use std::path::{Path, PathBuf};

--- a/tests/analyzer_test/analyze_test.rs
+++ b/tests/analyzer_test/analyze_test.rs
@@ -1,8 +1,9 @@
 #[cfg(test)]
 mod analyze_test {
     use indoc::indoc;
-    use balpan::analyzer::{Analyzer, Language, Traversable};
+    use balpan::analyzer::{Analyzer, Traversable};
     use balpan::grammar::{fetch_grammars, build_grammars};
+    use balpan::language::Language;
 
     fn assert_analyzed_source_code(source_code: &str, expected: &str, language: &str) {
         fetch_grammars().unwrap();

--- a/tests/analyzer_test/analyze_test.rs
+++ b/tests/analyzer_test/analyze_test.rs
@@ -1,8 +1,7 @@
-
 #[cfg(test)]
 mod analyze_test {
     use indoc::indoc;
-    use balpan::analyzer::{Analyzer,Traversable};
+    use balpan::analyzer::{Analyzer, Language, Traversable};
     use balpan::grammar::{fetch_grammars, build_grammars};
 
     fn assert_analyzed_source_code(source_code: &str, expected: &str, language: &str) {
@@ -11,7 +10,7 @@ mod analyze_test {
 
         let analyzer = Analyzer {
             source_code: source_code.to_string(),
-            language: language.to_string(),
+            language: Language::from(language),
         };
 
         let writer_queue = &analyzer.analyze();
@@ -102,7 +101,7 @@ mod analyze_test {
 
     #[test]
     fn test_trait_and_impl() {
-        let source_code = indoc! { "       
+        let source_code = indoc! { "
         pub trait RangeFactory {
             fn from_node(node: Node) -> Range;
         }
@@ -119,7 +118,7 @@ mod analyze_test {
             }
         }"};
 
-        let result = indoc! { "       
+        let result = indoc! { "
         /// [TODO]
         pub trait RangeFactory {
             fn from_node(node: Node) -> Range;
@@ -144,7 +143,7 @@ mod analyze_test {
 
     #[test]
     fn test_trait_and_impl_with_mod() {
-        let source_code = indoc! { "       
+        let source_code = indoc! { "
         mod tree_sitter_extended {
             pub trait RangeFactory {
                 fn from_node(node: Node) -> Range;
@@ -163,7 +162,7 @@ mod analyze_test {
             }
         }"};
 
-        let result = indoc! { "       
+        let result = indoc! { "
         /// [TODO]
         mod tree_sitter_extended {
             /// [TODO]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,7 +3,7 @@ mod integration_test {
     mod rust_test;
     mod python_test;
 
-    use balpan::analyzer::{Analyzer,Traversable};
+    use balpan::analyzer::{Analyzer,Language, Traversable};
     use balpan::grammar::{fetch_grammars, build_grammars};
 
     pub fn assert_analyzed_source_code(source_code: &str, expected: &str, language: &str) {
@@ -12,7 +12,7 @@ mod integration_test {
 
         let analyzer = Analyzer {
             source_code: source_code.to_string(),
-            language: language.to_string(),
+            language: Language::from(language),
         };
 
         let writer_queue = &analyzer.analyze();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,8 +3,9 @@ mod integration_test {
     mod rust_test;
     mod python_test;
 
-    use balpan::analyzer::{Analyzer,Language, Traversable};
+    use balpan::analyzer::{Analyzer, Traversable};
     use balpan::grammar::{fetch_grammars, build_grammars};
+    use balpan::language::Language;
 
     pub fn assert_analyzed_source_code(source_code: &str, expected: &str, language: &str) {
         fetch_grammars().unwrap();


### PR DESCRIPTION
Thank you for your positive response to the issue I submitted.

## linked issue

It resolve #28.

## works

- Change the `language` field of the Analyzer to a Language Enum.
- Replace to test code due to modifications in the constructor API caused by the type change of the `language` filed in the `Analyzer`.


### additional description

I've been considering where to place the Language Enum, but I haven't found the most suitable location yet. Do you think the current placement is okay? 



---
P.S. 
As I couldn't accurately determine the commit convention of this project, I followed a similar approach as much as possible. I hope this work proves to be helpful.:)