### PR TITLE
Extend tree-sitter node's behaviour with `ResolveSymbol` trait

### DIFF
--- a/src/tree_sitter_extended.rs
+++ b/src/tree_sitter_extended.rs
@@ -64,3 +64,36 @@ impl RangeFactory for Range {
         }
     }
 }
+
+pub trait ResolveSymbol {
+    fn identifier_range(&self) -> (usize, usize, usize);
+}
+
+impl ResolveSymbol for Node<'_> {
+    fn identifier_range(&self) -> (usize, usize, usize) {
+        if self.kind() == "attribute_item" {
+            return (0, 0, 0)
+        }
+
+        let mut node = self.child_by_field_name("name");
+
+        /// case of decorated_definition
+        if self.kind() == "decorated_definition" {
+            let definition_node = self.child_by_field_name("definition").unwrap();
+            node = definition_node.child_by_field_name("name");
+        }
+
+        /// case of impl_item
+        if self.kind() == "impl_item" {
+            node = self.child_by_field_name("trait");
+        }
+
+        let identifier_node = node.unwrap();
+        
+        let from = identifier_node.start_position().column;
+        let row = identifier_node.end_position().row;
+        let to = identifier_node.end_position().column;
+
+        (row, from, to)
+    }
+}


### PR DESCRIPTION
* tree-sitter node only represents its range, not name.
* Because treesitter node does not contain itself's name,
  we have to access named child such as `name`, `impl_item`