### PR TITLE
subcommand suggestion using distance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,7 @@ dependencies = [
  "log",
  "once_cell",
  "serde",
+ "strsim",
  "tempfile",
  "threadpool",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ libloading = "0.8.0"
 log = "0.4.18"
 once_cell = "1.18.0"
 serde = { version = "1.0", features = ["derive"] }
+strsim = "0.10.0"
 tempfile = "3.5.0"
 threadpool = "1.8.1"
 toml = "0.7.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use clap::Command;
 use balpan::scanner::Scanner;
 use balpan::utils::get_current_repository;
 use git2::Repository;
+use strsim::levenshtein;
 
 fn git(args: Vec<String>) {
     std::process::Command::new("git")
@@ -25,6 +26,30 @@ fn find_branch<'a>(repository: &Repository, target: &'a str) -> &'a str {
     ""
 }
 
+fn suggest_subcommand(input: &str) -> Option<&'static str> {
+    let subcommands = vec!["init", "reset"];
+
+    let mut closest = None;
+    let mut smallest_distance = usize::MAX;
+
+    const THRESHOLD: usize = 3;
+
+    for subcommand in subcommands {
+        let distance = levenshtein(input, subcommand);
+
+        match distance {
+            0 => return None,
+            1..=THRESHOLD if distance < smallest_distance => {
+                smallest_distance = distance;
+                closest = Some(subcommand);
+            }
+            _ => {}
+        }
+    }
+
+    closest
+}
+
 fn main() {
     let matches = Command::new("balpan")
             .version("0.2.0")
@@ -45,6 +70,16 @@ fn main() {
     let mut main_branch = String::new();
 
     let is_already_setup;
+
+    // verify that the subcommand entered is correct.
+    if let Some(command) = matches.subcommand_name() {
+        if suggest_subcommand(command).is_some() {
+            eprintln!("Did you mean '{}'?", suggest_subcommand(command).unwrap());
+            return;
+        }
+
+        eprintln!("`{}` is an unknown command. Enter `help` to check the list of available commands.", command);
+    }
 
     if matches.subcommand_matches("init").is_some() {
         let repo = get_current_repository().unwrap();
@@ -97,5 +132,23 @@ fn main() {
                 onboarding_branch,
             ])
         }
+    }
+}
+
+
+#[cfg(test)]
+mod main_tests {
+
+    #[test]
+    fn subcommand_suggestion() {
+        use super::suggest_subcommand;
+
+        assert_eq!(suggest_subcommand("innit"), Some("init"));
+        assert_eq!(suggest_subcommand("resett"), Some("reset"));
+        assert_eq!(suggest_subcommand("unknown"), None);
+        assert_eq!(suggest_subcommand("inot"), Some("init"));
+
+        assert_eq!(suggest_subcommand("init"), None);
+        assert_eq!(suggest_subcommand("reset"), None);
     }
 }


### PR DESCRIPTION
suggesting a subcommand when a typo is detected.

- return `None` directly when the Levenshtein distance is `0`, indicating that the subcommand is correct.
- set a threshold for the distance, beyond which no suggestions are provided.

Currently, the size of the command is not that large, so we are simply comparing it with levenshtein distance, but if the command grows later, we may need to consider using other string algorithms.