### PR TITLE
Fix a bug where `balpan init` produces unnecessary diff (empty line)

### DIFF
--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -42,6 +42,7 @@ impl Scanner {
                 if let Ok(mut file) = File::options().read(true).write(true).open(path) {
                     let mut source_code = String::new();
                     file.read_to_string(&mut source_code).unwrap();
+                    let with_empty_line = source_code.ends_with("\n");
                     let analyzer = Analyzer {
                         source_code,
                         language: language,
@@ -52,6 +53,10 @@ impl Scanner {
 
                     for line in writer_queue {
                         lines.push(String::from(line));
+                    }
+
+                    if with_empty_line {
+                        lines.push(String::new());
                     }
 
                     file.set_len(0).unwrap();


### PR DESCRIPTION
We expect to `balpan init` automatically generates TODO comments.

However, as you can see examples below,
current version of balpan not only generates TODO comments,
also removes last line break in a source code.

* Before : https://github.com/malkoG/python-dependency-injector/commit/7209798822fc6e23e7ac67cd216cb923dac59a5b - **Showing 202 changed files with 828 additions and 202 deletions.**
* After : https://github.com/malkoG/python-dependency-injector/commit/648b453fbb7f0972038e93dc24ca74e11660b5d7 - **Showing 169 changed files with 626 additions and 0 deletions.**