### PR TITLE
Use raw string literal for the codes on test cases.

### DIFF
--- a/tests/analyzer_test/analyze_test.rs
+++ b/tests/analyzer_test/analyze_test.rs
@@ -32,45 +32,45 @@ mod analyze_test {
 
     #[test]
     fn test_stacked_macros() {
-        let source_code = indoc! {"
+        let source_code = indoc! {r#"
             #[derive(Deserialize)]
-            #[serde(bound(deserialize = \"T: Deserialize<'de>\"))]
+            #[serde(bound(deserialize = "T: Deserialize<'de>"))]
             struct List<T> {
-                #[serde(deserialize_with = \"deserialize_vec\")]
+                #[serde(deserialize_with = "deserialize_vec")]
                 items: Vec<T>,
-            }"};
+            }"#};
 
-        let result = indoc! {"
+        let result = indoc! {r#"
             /// [TODO] List
             #[derive(Deserialize)]
-            #[serde(bound(deserialize = \"T: Deserialize<'de>\"))]
+            #[serde(bound(deserialize = "T: Deserialize<'de>"))]
             struct List<T> {
-                #[serde(deserialize_with = \"deserialize_vec\")]
+                #[serde(deserialize_with = "deserialize_vec")]
                 items: Vec<T>,
-            }"};
+            }"#};
 
         assert_analyzed_source_code(source_code, result, "rust")
     }
 
     #[test]
     fn test_idempotency() {
-        let source_code = indoc! {"
+        let source_code = indoc! {r#"
             /// [TODO] List
             #[derive(Deserialize)]
-            #[serde(bound(deserialize = \"T: Deserialize<'de>\"))]
+            #[serde(bound(deserialize = "T: Deserialize<'de>"))]
             struct List<T> {
-                #[serde(deserialize_with = \"deserialize_vec\")]
+                #[serde(deserialize_with = "deserialize_vec")]
                 items: Vec<T>,
-            }"};
+            }"#};
 
-        let result = indoc! {"
+        let result = indoc! {r#"
             /// [TODO] List
             #[derive(Deserialize)]
-            #[serde(bound(deserialize = \"T: Deserialize<'de>\"))]
+            #[serde(bound(deserialize = "T: Deserialize<'de>"))]
             struct List<T> {
-                #[serde(deserialize_with = \"deserialize_vec\")]
+                #[serde(deserialize_with = "deserialize_vec")]
                 items: Vec<T>,
-            }"};
+            }"#};
 
         assert_analyzed_source_code(source_code, result, "rust")
     }
@@ -181,18 +181,18 @@ mod analyze_test {
 
     #[test]
     fn test_ignore_doc_macro() {
-        let source_code = indoc! {"
-            #[doc = \"This is a doc comment\"]
+        let source_code = indoc! {r#"
+            #[doc = "This is a doc comment"]
             fn foo() {
-                println!(\"foo\");
-            }"};
+                println!("foo");
+            }"#};
 
-        let result = indoc! {"
+        let result = indoc! {r#"
             /// [TODO] foo
-            #[doc = \"This is a doc comment\"]
+            #[doc = "This is a doc comment"]
             fn foo() {
-                println!(\"foo\");
-            }"};
+                println!("foo");
+            }"#};
 
         assert_analyzed_source_code(source_code, result, "rust")
     }

--- a/tests/integration_test/python_test/django_case_test.rs
+++ b/tests/integration_test/python_test/django_case_test.rs
@@ -5,34 +5,34 @@ mod django_case_test {
 
     #[test]
     fn test_class_definition_within_class() {
-        let source_code = indoc! {"
+        let source_code = indoc! {r#"
         class Car(models.Model):
             name = models.CharField(max_length=20)
             default_parts = models.ManyToManyField(Part)
-            optional_parts = models.ManyToManyField(Part, related_name=\"cars_optional\")
+            optional_parts = models.ManyToManyField(Part, related_name="cars_optional")
 
             class Meta:
-                ordering = (\"name\",)"};
+                ordering = ("name",)"#};
 
-        let result = indoc! {"
+        let result = indoc! {r#"
         # [TODO] Car
         class Car(models.Model):
             name = models.CharField(max_length=20)
             default_parts = models.ManyToManyField(Part)
-            optional_parts = models.ManyToManyField(Part, related_name=\"cars_optional\")
+            optional_parts = models.ManyToManyField(Part, related_name="cars_optional")
 
             # [TODO] Car > Meta
             class Meta:
-                ordering = (\"name\",)"};
+                ordering = ("name",)"#};
 
         assert_analyzed_source_code(source_code, result, "python")
     }
 
     #[test]
     fn test_decorated_definitions_within_class_definition() {
-        let source_code = indoc! {"
+        let source_code = indoc! {r#"
         class Choices(enum.Enum, metaclass=ChoicesMeta):
-            \"\"\"Class for creating enumerated choices.\"\"\"
+            """Class for creating enumerated choices."""
 
             @DynamicClassAttribute
             def label(self):
@@ -40,12 +40,12 @@ mod django_case_test {
 
             @property
             def do_not_call_in_templates(self):
-                return True"};
+                return True"#};
 
-        let result = indoc! {"
+        let result = indoc! {r#"
         # [TODO] Choices
         class Choices(enum.Enum, metaclass=ChoicesMeta):
-            \"\"\"Class for creating enumerated choices.\"\"\"
+            """Class for creating enumerated choices."""
 
             # [TODO] Choices > label
             @DynamicClassAttribute
@@ -55,7 +55,7 @@ mod django_case_test {
             # [TODO] Choices > do_not_call_in_templates
             @property
             def do_not_call_in_templates(self):
-                return True"};
+                return True"#};
 
         assert_analyzed_source_code(source_code, result, "python")
     }

--- a/tests/integration_test/python_test/python_dependency_injector_case_test.rs
+++ b/tests/integration_test/python_test/python_dependency_injector_case_test.rs
@@ -5,57 +5,57 @@ mod python_dependency_injector_case_test {
 
     #[test]
     fn test_decorated_definition() {
-        let source_code = indoc! {"
-        @app.route(\"/\")
+        let source_code = indoc! {r#"
+        @app.route("/")
         @inject
         def index(service: Service = Provide[Container.service]):
             result = service.process()
-            return jsonify({\"result\": result})"};
+            return jsonify({"result": result})"#};
 
-        let result = indoc! {"
+        let result = indoc! {r#"
         # [TODO] index
-        @app.route(\"/\")
+        @app.route("/")
         @inject
         def index(service: Service = Provide[Container.service]):
             result = service.process()
-            return jsonify({\"result\": result})"};
+            return jsonify({"result": result})"#};
 
         assert_analyzed_source_code(source_code, result, "python")
     }
 
     #[test]
     fn test_decorated_async_function_definition() {
-        let source_code = indoc! {"
+        let source_code = indoc! {r#"
         @inject
         async def async_injection(
-                resource1: object = Provide[\"resource1\"],
-                resource2: object = Provide[\"resource2\"],
+                resource1: object = Provide["resource1"],
+                resource2: object = Provide["resource2"],
         ):
             return resource1, resource2
 
         @inject
         async def async_injection_with_closing(
-                resource1: object = Closing[Provide[\"resource1\"]],
-                resource2: object = Closing[Provide[\"resource2\"]],
+                resource1: object = Closing[Provide["resource1"]],
+                resource2: object = Closing[Provide["resource2"]],
         ):
-            return resource1, resource2"};
+            return resource1, resource2"#};
 
-        let result = indoc! {"
+        let result = indoc! {r#"
         # [TODO] async_injection
         @inject
         async def async_injection(
-                resource1: object = Provide[\"resource1\"],
-                resource2: object = Provide[\"resource2\"],
+                resource1: object = Provide["resource1"],
+                resource2: object = Provide["resource2"],
         ):
             return resource1, resource2
 
         # [TODO] async_injection_with_closing
         @inject
         async def async_injection_with_closing(
-                resource1: object = Closing[Provide[\"resource1\"]],
-                resource2: object = Closing[Provide[\"resource2\"]],
+                resource1: object = Closing[Provide["resource1"]],
+                resource2: object = Closing[Provide["resource2"]],
         ):
-            return resource1, resource2"};
+            return resource1, resource2"#};
 
         assert_analyzed_source_code(source_code, result, "python")
     }

--- a/tests/integration_test/python_test/rustpython_case_test.rs
+++ b/tests/integration_test/python_test/rustpython_case_test.rs
@@ -7,18 +7,18 @@ mod rustpython_case_test {
     ///
     #[test]
     fn test_class_definition() {
-        let source_code = indoc! {"
+        let source_code = indoc! {r#"
         class FeedParser:
-            \"\"\"A feed-style parser of email.\"\"\"
+            """A feed-style parser of email."""
 
             def __init__(self, _factory=None, *, policy=compat32):
-                \"\"\"_factory is called with no arguments to create a new message obj
+                """_factory is called with no arguments to create a new message obj
 
                 The policy keyword specifies a policy object that controls a number of
                 aspects of the parser's operation.  The default policy maintains
                 backward compatibility.
 
-                \"\"\"
+                """
                 self.policy = policy
                 self._old_style_factory = False
                 if _factory is None:
@@ -46,7 +46,7 @@ mod rustpython_case_test {
                 self._headersonly = True
 
             def feed(self, data):
-                \"\"\"Push more data into the parser.\"\"\"
+                """Push more data into the parser."""
                 self._input.push(data)
                 self._call_parse()
 
@@ -54,22 +54,22 @@ mod rustpython_case_test {
                 try:
                     self._parse()
                 except StopIteration:
-                    pass"};
+                    pass"#};
 
-        let result = indoc! {"
+        let result = indoc! {r#"
         # [TODO] FeedParser
         class FeedParser:
-            \"\"\"A feed-style parser of email.\"\"\"
+            """A feed-style parser of email."""
 
             # [TODO] FeedParser > __init__
             def __init__(self, _factory=None, *, policy=compat32):
-                \"\"\"_factory is called with no arguments to create a new message obj
+                """_factory is called with no arguments to create a new message obj
 
                 The policy keyword specifies a policy object that controls a number of
                 aspects of the parser's operation.  The default policy maintains
                 backward compatibility.
 
-                \"\"\"
+                """
                 self.policy = policy
                 self._old_style_factory = False
                 if _factory is None:
@@ -99,7 +99,7 @@ mod rustpython_case_test {
 
             # [TODO] FeedParser > feed
             def feed(self, data):
-                \"\"\"Push more data into the parser.\"\"\"
+                """Push more data into the parser."""
                 self._input.push(data)
                 self._call_parse()
 
@@ -108,7 +108,7 @@ mod rustpython_case_test {
                 try:
                     self._parse()
                 except StopIteration:
-                    pass"};
+                    pass"#};
 
         assert_analyzed_source_code(source_code, result, "python")
     }

--- a/tests/integration_test/rust_test/anyhow_case_test.rs
+++ b/tests/integration_test/rust_test/anyhow_case_test.rs
@@ -5,34 +5,34 @@ mod anyhow_case_test {
 
     #[test]
     fn test_declaring_error_enum_with_macro() {
-        let source_code = indoc! {"
+        let source_code = indoc! {r#"
         use thiserror::Error;
 
         #[derive(Error, Debug)]
         pub enum FormatError {
-            #[error(\"Invalid header (expected {expected:?}, got {found:?})\")]
+            #[error("Invalid header (expected {expected:?}, got {found:?})")]
             InvalidHeader {
                 expected: String,
                 found: String,
             },
-            #[error(\"Missing attribute: {0}\")]
+            #[error("Missing attribute: {0}")]
             MissingAttribute(String),
-        }"};
+        }"#};
 
-        let result = indoc! {"
+        let result = indoc! {r#"
         use thiserror::Error;
 
         /// [TODO] FormatError
         #[derive(Error, Debug)]
         pub enum FormatError {
-            #[error(\"Invalid header (expected {expected:?}, got {found:?})\")]
+            #[error("Invalid header (expected {expected:?}, got {found:?})")]
             InvalidHeader {
                 expected: String,
                 found: String,
             },
-            #[error(\"Missing attribute: {0}\")]
+            #[error("Missing attribute: {0}")]
             MissingAttribute(String),
-        }"};
+        }"#};
 
         assert_analyzed_source_code(source_code, result, "rust")
     }

--- a/tests/integration_test/rust_test/rustpython_case_test.rs
+++ b/tests/integration_test/rust_test/rustpython_case_test.rs
@@ -5,37 +5,37 @@ mod rustpython_case_test {
 
     #[test]
     fn test_declaring_enum_with_stacked_attribute() {
-        let source_code = indoc! {"
+        let source_code = indoc! {r#"
         #[derive(Debug, thiserror::Error)]
         #[non_exhaustive]
         pub enum JitCompileError {
-            #[error(\"function can't be jitted\")]
+            #[error("function can't be jitted")]
             NotSupported,
-            #[error(\"bad bytecode\")]
+            #[error("bad bytecode")]
             BadBytecode,
-            #[error(\"error while compiling to machine code: {0}\")]
+            #[error("error while compiling to machine code: {0}")]
             CraneliftError(#[from] ModuleError),
         }
 
         #[derive(Debug, thiserror::Error, Eq, PartialEq)]
         #[non_exhaustive]
         pub enum JitArgumentError {
-            #[error(\"argument is of wrong type\")]
+            #[error("argument is of wrong type")]
             ArgumentTypeMismatch,
-            #[error(\"wrong number of arguments\")]
+            #[error("wrong number of arguments")]
             WrongNumberOfArguments,
-        }"};
+        }"#};
 
-        let result = indoc! {"
+        let result = indoc! {r#"
         /// [TODO] JitCompileError
         #[derive(Debug, thiserror::Error)]
         #[non_exhaustive]
         pub enum JitCompileError {
-            #[error(\"function can't be jitted\")]
+            #[error("function can't be jitted")]
             NotSupported,
-            #[error(\"bad bytecode\")]
+            #[error("bad bytecode")]
             BadBytecode,
-            #[error(\"error while compiling to machine code: {0}\")]
+            #[error("error while compiling to machine code: {0}")]
             CraneliftError(#[from] ModuleError),
         }
 
@@ -43,11 +43,11 @@ mod rustpython_case_test {
         #[derive(Debug, thiserror::Error, Eq, PartialEq)]
         #[non_exhaustive]
         pub enum JitArgumentError {
-            #[error(\"argument is of wrong type\")]
+            #[error("argument is of wrong type")]
             ArgumentTypeMismatch,
-            #[error(\"wrong number of arguments\")]
+            #[error("wrong number of arguments")]
             WrongNumberOfArguments,
-        }"};
+        }"#};
 
         assert_analyzed_source_code(source_code, result, "rust")
     }


### PR DESCRIPTION
Rust provides the "Raw string literals" similar to Python's triple-quote string literal. It will be more suitable for code that contains several quote characters.