### PR TITLE
(rust) Fix a bug where accessing name of impl node for struct(not for trait) raises error

### DIFF
--- a/src/tree_sitter_extended.rs
+++ b/src/tree_sitter_extended.rs
@@ -84,7 +84,11 @@ impl ResolveSymbol for Node<'_> {
 
         // case of impl_item
         if self.kind() == "impl_item" {
-            node = self.child_by_field_name("trait");
+            node = self.child_by_field_name("trait"); // impl Foo for Bar
+            node = match node {
+                None => self.child_by_field_name("type"), // impl Foo
+                result => result,
+            }
         }
 
         let identifier_node = node.unwrap();


### PR DESCRIPTION
Here is intuitive example.

Code snippet:

```rust
impl Foo {

}

impl Foo for Bar {

}
```

Syntax Tree:

```
source_file [0, 0] - [7, 0]
  impl_item [0, 0] - [2, 1]
    type: type_identifier [0, 5] - [0, 8]
    body: declaration_list [0, 9] - [2, 1]
  impl_item [4, 0] - [6, 1]
    trait: type_identifier [4, 5] - [4, 8]
    type: type_identifier [4, 13] - [4, 16]
    body: declaration_list [4, 17] - [6, 1]
```

That is,
If we want to access name of **impl for struct**, we have to access named child node `type`.
If we want to access name of **impl for trait**, we have to access named child node `trait`.