### PR TITLE
(rust) Fix a bug where attribute_item is moved to improper position when running analyze()

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -100,6 +100,30 @@ impl<'tree> Traversable<'tree> for Analyzer {
             match Range::from_node(*current_node) {
                 node_range if cursor_position.is_member_of(node_range) => {
                     let node_type = current_node.kind();
+
+                    // rust specific code
+                    if node_type == "mod_item" {
+                        if node_range.start_point.row == node_range.end_point.row {
+                            while !pending_queue.is_empty() {
+                                let decorator_line: &str = pending_queue.pop_front().unwrap();
+                                writer_queue.push_back(decorator_line.to_owned());
+                            }
+                            writer_queue.push_back(line.to_owned());
+                            nodes_queue.pop_front();
+                            continue;
+                        }
+                    }
+
+                    if ignorable_node_types.contains(&node_type) {
+                        while !pending_queue.is_empty() {
+                            let decorator_line: &str = pending_queue.pop_front().unwrap();
+                            writer_queue.push_back(decorator_line.to_owned());
+                        }
+                        writer_queue.push_back(line.to_owned());
+                        nodes_queue.pop_front();
+                        continue;
+                    }
+
                     if node_type == self.language.decorator_node_type() {
                         pending_queue.push_back(line);
                     } else {

--- a/src/language.rs
+++ b/src/language.rs
@@ -63,6 +63,9 @@ impl Language {
                 "extern_crate_declaration",
                 "const_item",
                 "use_declaration",
+                "expression_statement",
+                "macro_invocation",
+                "foreign_mod_item", // extern "C"
             ],
             _ => vec![]
         }

--- a/src/tree_sitter_extended.rs
+++ b/src/tree_sitter_extended.rs
@@ -74,6 +74,22 @@ impl ResolveSymbol for Node<'_> {
             return (0, 0, 0);
         }
 
+        if self.kind() == "use_declaration" {
+            return (0, 0, 0);
+        }
+
+        if self.kind() == "macro_invocation" {
+            return (0, 0, 0)
+        }
+
+        if self.kind() == "expression_statement" {
+            return (0, 0, 0)
+        }
+
+        if self.kind() == "foreign_mod_item" {
+            return (0, 0, 0)
+        }
+
         let mut node = self.child_by_field_name("name");
 
         // case of decorated_definition

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -25,6 +25,11 @@ mod integration_test {
 
         let actual: String = string_vector.join("\n");
 
+        if actual != expected {
+            println!("expected: {}\n\n", expected);
+            println!("actual: {}\n\n", actual);
+        }
+
         assert_eq!(expected, actual);
     }
 }

--- a/tests/integration_test/rust_test/rustpython_case_test.rs
+++ b/tests/integration_test/rust_test/rustpython_case_test.rs
@@ -3,6 +3,7 @@ mod rustpython_case_test {
     use crate::integration_test::assert_analyzed_source_code;
     use indoc::indoc;
 
+    /// https://github.com/RustPython/RustPython/blob/bdb0c8f64557e0822f0bcfd63defbad54625c17a/jit/src/lib.rs#L10-L28
     #[test]
     fn test_declaring_enum_with_stacked_attribute() {
         let source_code = indoc! {r#"
@@ -47,6 +48,69 @@ mod rustpython_case_test {
             ArgumentTypeMismatch,
             #[error("wrong number of arguments")]
             WrongNumberOfArguments,
+        }"#};
+
+        assert_analyzed_source_code(source_code, result, "rust")
+    }
+
+    /// https://github.com/RustPython/RustPython/blob/bdb0c8f64557e0822f0bcfd63defbad54625c17a/vm/src/compiler.rs#L5C1-L6
+    #[test]
+    fn test_macro_above_use_declaration_should_be_ignored() {
+        let source_code = indoc! { r#" 
+        #[cfg(feature = "rustpython-compiler")]
+        use rustpython_compiler::*;"#};
+
+        let result = indoc! { r#" 
+        #[cfg(feature = "rustpython-compiler")]
+        use rustpython_compiler::*;"#};
+
+        assert_analyzed_source_code(source_code, result, "rust")
+    }  
+
+
+    /// https://github.com/RustPython/RustPython/blob/bdb0c8f64557e0822f0bcfd63defbad54625c17a/wasm/lib/src/js_module.rs#L24-L55
+    #[test]
+    fn test_macro_above_extern_c_module() {
+        let source_code = indoc! { r#"
+        #[wasm_bindgen(inline_js = "
+        export function has_prop(target, prop) { return prop in Object(target); }
+        export function get_prop(target, prop) { return target[prop]; }
+        export function set_prop(target, prop, value) { target[prop] = value; }
+        export function type_of(a) { return typeof a; }
+        export function instance_of(lhs, rhs) { return lhs instanceof rhs; }
+        ")]
+        extern "C" {
+            #[wasm_bindgen(catch)]
+            fn has_prop(target: &JsValue, prop: &JsValue) -> Result<bool, JsValue>;
+            #[wasm_bindgen(catch)]
+            fn get_prop(target: &JsValue, prop: &JsValue) -> Result<JsValue, JsValue>;
+            #[wasm_bindgen(catch)]
+            fn set_prop(target: &JsValue, prop: &JsValue, value: &JsValue) -> Result<(), JsValue>;
+            #[wasm_bindgen]
+            fn type_of(a: &JsValue) -> String;
+            #[wasm_bindgen(catch)]
+            fn instance_of(lhs: &JsValue, rhs: &JsValue) -> Result<bool, JsValue>;
+        }"#};
+
+        let result = indoc! { r#"
+        #[wasm_bindgen(inline_js = "
+        export function has_prop(target, prop) { return prop in Object(target); }
+        export function get_prop(target, prop) { return target[prop]; }
+        export function set_prop(target, prop, value) { target[prop] = value; }
+        export function type_of(a) { return typeof a; }
+        export function instance_of(lhs, rhs) { return lhs instanceof rhs; }
+        ")]
+        extern "C" {
+            #[wasm_bindgen(catch)]
+            fn has_prop(target: &JsValue, prop: &JsValue) -> Result<bool, JsValue>;
+            #[wasm_bindgen(catch)]
+            fn get_prop(target: &JsValue, prop: &JsValue) -> Result<JsValue, JsValue>;
+            #[wasm_bindgen(catch)]
+            fn set_prop(target: &JsValue, prop: &JsValue, value: &JsValue) -> Result<(), JsValue>;
+            #[wasm_bindgen]
+            fn type_of(a: &JsValue) -> String;
+            #[wasm_bindgen(catch)]
+            fn instance_of(lhs: &JsValue, rhs: &JsValue) -> Result<bool, JsValue>;
         }"#};
 
         assert_analyzed_source_code(source_code, result, "rust")

--- a/tests/integration_test/rust_test/serde_case_test.rs
+++ b/tests/integration_test/rust_test/serde_case_test.rs
@@ -51,4 +51,91 @@ mod serde_case_test {
 
         assert_analyzed_source_code(source_code, result, "rust")
     }
+
+
+    /// https://github.com/serde-rs/serde/blob/7b548db91ed7da81a5c0ddbd6f6f21238aacfebe/serde/src/lib.rs#L155-L156
+    #[test]
+    fn test_macro_above_extern_crate_declaration_should_be_ignored() {
+        let source_code = indoc! { r#"
+        #[cfg(feature = "alloc")]
+         extern crate alloc;"#};
+
+        let result = indoc! { r#"
+        #[cfg(feature = "alloc")]
+         extern crate alloc;"#};
+
+        assert_analyzed_source_code(source_code, result, "rust");
+    }
+
+    /// https://github.com/serde-rs/serde/blob/7b548db91ed7da81a5c0ddbd6f6f21238aacfebe/precompiled/bin/main.rs#L11-L12
+    #[test]
+    fn test_macro_above_static_variable_should_be_ignored() {
+        let source_code = indoc! {r#"
+        #[global_allocator]
+        static ALLOCATOR: MonotonicAllocator = MonotonicAllocator;"#};
+
+        let result = indoc! {r#"
+        #[global_allocator]
+        static ALLOCATOR: MonotonicAllocator = MonotonicAllocator;"#};
+
+        assert_analyzed_source_code(source_code, result, "rust")
+    }
+
+    /// https://github.com/serde-rs/serde/blob/7b548db91ed7da81a5c0ddbd6f6f21238aacfebe/serde/src/de/impls.rs#L1783-L1793
+    #[test]
+    fn test_macro_above_macro_invocation_should_be_ignored() {
+        let source_code = indoc! { r#" 
+        #[cfg(any(feature = "std", feature = "alloc"))]
+        forwarded_impl!((T), Box<T>, Box::new);
+         
+        #[cfg(any(feature = "std", feature = "alloc"))]
+        forwarded_impl!((T), Box<[T]>, Vec::into_boxed_slice);
+         
+        #[cfg(any(feature = "std", feature = "alloc"))]
+        forwarded_impl!((), Box<str>, String::into_boxed_str);
+         
+        #[cfg(all(feature = "std", any(unix, windows)))]
+        forwarded_impl!((), Box<OsStr>, OsString::into_boxed_os_str);"#};
+
+        let result = indoc! { r#" 
+        #[cfg(any(feature = "std", feature = "alloc"))]
+        forwarded_impl!((T), Box<T>, Box::new);
+         
+        #[cfg(any(feature = "std", feature = "alloc"))]
+        forwarded_impl!((T), Box<[T]>, Vec::into_boxed_slice);
+         
+        #[cfg(any(feature = "std", feature = "alloc"))]
+        forwarded_impl!((), Box<str>, String::into_boxed_str);
+         
+        #[cfg(all(feature = "std", any(unix, windows)))]
+        forwarded_impl!((), Box<OsStr>, OsString::into_boxed_os_str);"#};
+
+        assert_analyzed_source_code(source_code, result, "rust")
+    }
+
+    /// https://github.com/serde-rs/serde/blob/7b548db91ed7da81a5c0ddbd6f6f21238aacfebe/serde/src/de/mod.rs#L119-L126
+    #[test]
+    fn test_ignore_mod_items_in_a_row() {
+        let source_code = indoc! { r#"
+         pub mod value;
+         
+         #[cfg(not(no_integer128))]
+         mod format;
+         mod ignored_any;
+         mod impls;
+         pub(crate) mod size_hint;
+         mod utf8;"#};
+
+        let result = indoc! { r#"
+         pub mod value;
+         
+         #[cfg(not(no_integer128))]
+         mod format;
+         mod ignored_any;
+         mod impls;
+         pub(crate) mod size_hint;
+         mod utf8;"#};
+
+         assert_analyzed_source_code(source_code, result, "rust");
+    }
 }


### PR DESCRIPTION
closes: #6 

After `balpan init`, running `git diff | grep ^-` would be helpful