### PR TITLE
Refactor Analyzer's analyze method

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -13,14 +13,7 @@ pub struct Analyzer {
     pub language: Language,
 }
 
-pub trait Traversable<'tree> {
-    fn get_indent_comment_pool(&self) -> Vec<String>;
-    fn analyze(&self) -> VecDeque<String>;
-    fn get_syntax_tree(&self) -> Tree;
-    fn get_scannable_nodes(&self, tree: &'tree Tree) -> Vec<(Node<'tree>, (usize, usize, usize))>;
-}
-
-impl<'tree> Traversable<'tree> for Analyzer {
+impl<'tree> Analyzer {
     fn get_indent_comment_pool(&self) -> Vec<String> {
         // let comment = match self.language {
         //     Language::Rust => "/// [TODO]",

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use git2::Repository;
 
-use crate::analyzer::{Analyzer, Traversable};
+use crate::analyzer::Analyzer;
 use crate::grammar::{build_grammars, fetch_grammars};
 use crate::language::Language;
 use crate::utils::list_available_files;

--- a/tests/analyzer_test/analyze_test.rs
+++ b/tests/analyzer_test/analyze_test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod analyze_test {
-    use balpan::analyzer::{Analyzer, Traversable};
+    use balpan::analyzer::Analyzer;
     use balpan::grammar::{build_grammars, fetch_grammars};
     use balpan::language::Language;
     use indoc::indoc;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4,7 +4,7 @@ mod integration_test {
     mod rust_test;
     mod ruby_test;
 
-    use balpan::analyzer::{Analyzer, Traversable};
+    use balpan::analyzer::Analyzer;
     use balpan::grammar::{build_grammars, fetch_grammars};
     use balpan::language::Language;
 


### PR DESCRIPTION
* Removed unnecessary `Traversable` trait
* Extracted part of breath-first search into separated method `enqueue_child_nodes`
* As number of supported languages increase,
  `enqueue_child_nodes`'s behaviour will be more various, and it can be more larger.