### PR TITLE
analyze command added

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,7 @@ dependencies = [
  "clap",
  "etcetera",
  "git2",
+ "glob",
  "ignore",
  "indoc",
  "libloading",
@@ -299,6 +300,12 @@ dependencies = [
  "openssl-sys",
  "url",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ cc = "1.0.79"
 clap = { version = "4.3.21", features = ["derive"] }
 etcetera = "0.8.0"
 git2 = "0.17.2"
+glob = "0.3.1"
 ignore = "0.4.20"
 indoc = "2.0.3"
 libloading = "0.8.0"

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -124,7 +124,7 @@ impl<'tree> Analyzer {
                         let node_symbol_with_indent = &lines[*row];
                         let node_symbol = &node_symbol_with_indent[from.to_owned()..to.to_owned()];
 
-                        if from.to_owned() == 0 && to.to_owned() == 0 {
+                        if *from == 0 && *to == 0 {
                             symbol_name_with_context.push_str("anonymous");
                         } else {
                             symbol_name_with_context.push_str(node_symbol);
@@ -163,7 +163,7 @@ impl<'tree> Analyzer {
                         let (_, from, to) = current_node.identifier_range();
                         
                         let mut symbol = String::new();
-                        if from.to_owned() == 0 && to.to_owned() == 0 {
+                        if from == 0 && to == 0 {
                             symbol = "anonymous".to_string();
                         } else {
                             symbol = line[from.to_owned()..to.to_owned()].to_string();
@@ -213,7 +213,7 @@ impl<'tree> Analyzer {
     /// This methods collects treesitter nodes with BFS
     ///
     /// All of tree sitter nodes are ordered by non decreasing order
-    fn get_scannable_nodes<'b>(&self, tree: &'tree Tree) -> Vec<(Node<'tree>, (usize, usize, usize))> {
+    fn get_scannable_nodes(&self, tree: &'tree Tree) -> Vec<(Node<'tree>, (usize, usize, usize))> {
         let mut deq: VecDeque<Node<'tree>> = VecDeque::new();
         let scannable_node_types = self.language.scannable_node_types();
         let nested_traversable_symbols = self.language.nested_traversable_symbols();
@@ -276,6 +276,6 @@ impl<'tree> Analyzer {
             }
         }
 
-        return deq
+        deq
     }
 }

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -92,16 +92,15 @@ impl<'tree> Analyzer {
                     let node_type = current_node.kind();
 
                     // rust specific code
-                    if node_type == "mod_item" {
-                        if node_range.start_point.row == node_range.end_point.row {
-                            while !pending_queue.is_empty() {
-                                let decorator_line: &str = pending_queue.pop_front().unwrap();
-                                writer_queue.push_back(decorator_line.to_owned());
-                            }
-                            writer_queue.push_back(line.to_owned());
-                            nodes_queue.pop_front();
-                            continue;
+                    if node_type == "mod_item" && node_range.start_point.row == node_range.end_point.row {
+                        while !pending_queue.is_empty() {
+                            let decorator_line: &str = pending_queue.pop_front().unwrap();
+                            writer_queue.push_back(decorator_line.to_owned());
                         }
+
+                        writer_queue.push_back(line.to_owned());
+                        nodes_queue.pop_front();
+                        continue;
                     }
 
                     if ignorable_node_types.contains(&node_type) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ use std::path::Path;
 use std::time::Instant;
 
 use balpan::commands::pattern_search::PatternTree;
-use balpan::grammar::{fetch_grammars, build_grammars};
 use clap::{Parser, Subcommand};
 use glob::glob;
 
@@ -86,6 +85,13 @@ fn main() {
             println!("time: {:?}", time.elapsed());
         }
         BalpanCommand::Analyze { pattern } => {
+            match pattern {
+                Some(ref p) => if !p.starts_with('"') || !p.ends_with('"') {
+                    panic!("Invalid file path. Please include double quotes(`\"`) in the path.")
+                },
+                None => panic!("No file specified. Please specify a file path to analyze")
+            }
+
             let runtime = create_runtime();
 
             runtime.block_on(async {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,9 @@ use std::path::Path;
 use std::time::Instant;
 
 use balpan::commands::pattern_search::PatternTree;
+use balpan::grammar::{fetch_grammars, build_grammars};
 use clap::{Parser, Subcommand};
+use glob::glob;
 
 use balpan::commands::grep::GrepReport;
 use balpan::scanner::Scanner;
@@ -35,6 +37,11 @@ enum BalpanCommand {
         )]
         format: Option<String>,
     },
+    #[clap(about = "Generate a TODO comment for specific file")]
+    Analyze {
+        #[clap(short, long, help = "Specific file to scan")]
+        pattern: Option<String>,
+    }
 }
 
 fn create_runtime() -> Runtime {
@@ -77,6 +84,13 @@ fn main() {
             });
 
             println!("time: {:?}", time.elapsed());
+        }
+        BalpanCommand::Analyze { pattern } => {
+            let runtime = create_runtime();
+
+            runtime.block_on(async {
+                handle_analyze(pattern).await;
+            });
         }
     }
 }
@@ -141,7 +155,6 @@ fn handle_reset() {
 
 async fn handle_init() {
     let repo = get_current_repository().unwrap();
-    // let onboarding_branch = find_branch(&repo, "onboarding").to_owned();
     let mut is_already_setup: bool = false;
 
     let _onboarding_branch = match find_branch(&repo, "onboarding") {
@@ -189,6 +202,22 @@ async fn handle_grep(
 
     let formatting = report.report_formatting(format);
     println!("{}", formatting);
+}
+
+async fn handle_analyze(pattern: Option<String>) {
+    if pattern.is_none() {
+        panic!("No file specified. Please specify a file path to analyze")
+    }
+
+    let file_pattern_str = pattern.unwrap();
+    let filter = glob(&file_pattern_str).expect("Failed to read file pattern");
+
+    for entry in filter {
+        match entry {
+            Ok(path) => Scanner::scan_specific_file(path).await,
+            Err(e) => println!("Error while reading file pattern: {}", e),
+        }
+    }
 }
 
 async fn scan_project_directory(

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
 use std::io::{Read, Seek, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use git2::Repository;
 
@@ -12,13 +12,12 @@ use crate::utils::list_available_files;
 pub struct Scanner;
 
 impl Scanner {
-    #[inline]
     pub async fn scan(repo: &Repository) {
         fetch_grammars().unwrap();
         build_grammars(None).unwrap();
 
         if let Some(workdir) = repo.workdir() {
-            let repo_root = workdir.to_string_lossy().to_string();
+            let repo_root = workdir.to_string_lossy();
             let filenames = list_available_files(&repo_root);
             for filename in filenames.await {
                 if filename.contains("test") {
@@ -29,11 +28,6 @@ impl Scanner {
                     Some(os_str) => Language::from_extension(os_str.to_str().unwrap()),
                     _ => Language::Other("".to_string()),
                 };
-
-                // match language {
-                //     Language::Other(_) => continue,
-                //     _ => {}
-                // };
 
                 if let Language::Other(_) = language {
                     continue;
@@ -64,6 +58,43 @@ impl Scanner {
                     file.write_all(lines.join("\n").as_bytes()).unwrap();
                 }
             }
+        }
+    }
+
+    /// Scan a specific file and add TODO comments
+    pub async fn scan_specific_file(path: PathBuf) {
+        fetch_grammars().unwrap();
+        build_grammars(None).unwrap();
+
+        if let Ok(mut file) = File::options().read(true).write(true).open(path.clone()) {
+            let mut source_code = String::new();
+            file.read_to_string(&mut source_code).unwrap();
+            let with_empty_line = source_code.ends_with('\n');
+
+            let language = match path.extension() {
+                Some(p) => Language::from_extension(p.to_str().unwrap()),
+                _ => Language::Other("".to_string()),
+            };
+
+            let analyzer = Analyzer {
+                source_code,
+                language,
+            };
+
+            let writer_queue = &analyzer.analyze();
+            let mut lines: Vec<String> = vec![];
+
+            for line in writer_queue {
+                lines.push(String::from(line));
+            }
+
+            if with_empty_line {
+                lines.push(String::new());
+            }
+
+            file.set_len(0).unwrap();
+            file.rewind().unwrap();
+            file.write_all(lines.join("\n").as_bytes()).unwrap();
         }
     }
 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -73,7 +73,7 @@ impl Scanner {
 
             let language = match path.extension() {
                 Some(p) => Language::from_extension(p.to_str().unwrap()),
-                _ => Language::Other("".to_string()),
+                _ => Language::Other(String::new()),
             };
 
             let analyzer = Analyzer {

--- a/src/tree_sitter_extended.rs
+++ b/src/tree_sitter_extended.rs
@@ -92,18 +92,13 @@ impl ResolveSymbol for Node<'_> {
 
         let mut node = self.child_by_field_name("name");
 
-        if self.kind() == "namespace_definition" {
-            if node == None {
-                return (0, 0, 0)
-            }
+        if self.kind() == "namespace_definition" && node.is_none() {
+            return (0, 0, 0)
         }
 
         if self.kind() == "function_definition" {
-            match self.child_by_field_name("declarator") {
-                Some(child) => {
-                    node = child.child_by_field_name("declarator");
-                },
-                None => {}
+            if let Some(child) = self.child_by_field_name("declarator") {
+                node = child.child_by_field_name("declarator");
             }
         }
 


### PR DESCRIPTION
## :star2: What does this PR do?

Implemented the `analyze` command to scan files for specific path patterns and add TODO annotations. I used a glob to navigate to the file path.

## :bug: Recommendations for testing

Currently, it only works if you enclose the file pattern in double quotes, which I think should be changed to a vector so it can be handled later.

## :memo: Links to relevant issues or information

#31 [Feature] balpan analyze subcommand
