### PR TITLE
Support more options for grep commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,7 @@ dependencies = [
  "libloading",
  "log",
  "once_cell",
+ "regex",
  "serde",
  "serde_json",
  "strsim",
@@ -504,9 +505,9 @@ checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "miniz_oxide"
@@ -641,9 +642,21 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.3"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
+checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+dependencies = [
+ "aho-corasick 1.0.4",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
 dependencies = [
  "aho-corasick 1.0.4",
  "memchr",
@@ -652,9 +665,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ indoc = "2.0.3"
 libloading = "0.8.0"
 log = "0.4.18"
 once_cell = "1.18.0"
+regex = "1.9.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.104"
 strsim = "0.10.0"

--- a/src/commands/grep.rs
+++ b/src/commands/grep.rs
@@ -139,39 +139,55 @@ impl GrepReport {
         result
     }
 
-    fn format_plain(&self) -> String {
+    fn format_plain(&self, hide_path: bool, list_of_files: bool, count: bool) -> String {
         let mut result = String::new();
-
-        for dir in &self.directories {
-            let path = Path::new(&dir.name);
-
-            dir_path_pretty(path, &mut result);
-
-            for file in &dir.files {
-                let file_name = Path::new(&file.name);
-                let last_two = last_two(file_name);
-                result.push_str(&format!("{}\n", last_two[0]));
-
-                for item in &file.items {
-                    result.push_str(&format!("{}    {}", item.line, item.content.trim_start()));
+        let mut counter: usize = 0;
+    
+        if !count {
+            for dir in &self.directories {
+                let path = Path::new(&dir.name);
+    
+                if !hide_path {
+                    dir_path_pretty(path, &mut result);
                 }
-
-                result.push('\n');
+    
+                for file in &dir.files {
+                    if !hide_path {
+                        let file_name = Path::new(&file.name);
+                        let last_two = last_two(file_name);
+                        result.push_str(&format!("{}\n", last_two[0]));
+                    }
+    
+                    if !list_of_files {
+                        for item in &file.items {
+                            result.push_str(&format!("{}    {}", item.line, item.content.trim_start()));
+                            counter += 1;
+                        }
+                        result.push('\n');
+                    } else {
+                        counter += file.items.len();
+                    }
+                }
             }
-
-            result.push('\n');
+            result.push_str(&format!("\nTotal {} lines found\n", counter));
+        } else {
+            counter = self.directories
+                .iter()
+                .map(|dir| dir.files.iter().map(|file| file.items.len())
+                .sum::<usize>()).sum();
+            result = format!("Total {} lines found\n", counter);
         }
-
+    
         result
     }
 
-    pub fn report_formatting(&mut self, format: Option<String>) -> String {
+    pub fn report_formatting(&mut self, format: Option<String>, hide_path: bool, list_of_files: bool, count: bool) -> String {
         let default = "plain".to_string();
         let format = format.unwrap_or(default);
 
         match format.as_str() {
             "json" => serde_json::to_string_pretty(self).unwrap(),
-            "plain" => self.format_plain(),
+            "plain" => self.format_plain(hide_path, list_of_files, count),
             // "tree" => self.format_tree(4),
             _ => {
                 let suggest = suggest_subcommand(&format).unwrap();

--- a/src/commands/pattern_search.rs
+++ b/src/commands/pattern_search.rs
@@ -2,14 +2,18 @@ use crate::commands::boyer_moore::{BoyerMooreSearch, SearchIn};
 use aho_corasick::AhoCorasick;
 
 #[derive(Debug, Clone)]
-pub struct PatternTree;
+pub struct PatternTree {
+    pub ignore_case: bool,
+}
 
 type PatternPosition = (bool, Vec<usize>);
 
 #[allow(clippy::new_without_default)]
 impl PatternTree {
     pub fn new() -> Self {
-        PatternTree
+        PatternTree {
+            ignore_case: false,
+        }
     }
 
     /// Call all search methods based on the given patterns
@@ -22,8 +26,25 @@ impl PatternTree {
     pub fn selective_search(&self, patterns: &Vec<String>, text: &str) -> PatternPosition {
         match patterns.len() {
             0 => (false, vec![]),
-            1 => self.boyer_moore_search(text, &patterns[0]),
-            _ => self.aho_corasick_search(text, patterns),
+            1 => {
+                match self.ignore_case {
+                    true => self.boyer_moore_search(&text.to_lowercase(), &patterns[0].to_lowercase()),
+                    false => self.boyer_moore_search(text, &patterns[0]),
+                }
+            },
+            _ => {
+                if self.ignore_case {
+                    let mut lower_patterns: Vec<String> = Vec::new();
+
+                    for pattern in patterns {
+                        lower_patterns.push(pattern.to_lowercase());
+                    }
+
+                    self.aho_corasick_search(&text.to_lowercase(), &lower_patterns)
+                } else {
+                    self.aho_corasick_search(text, patterns)
+                }
+            },
         }
     }
 

--- a/src/commands/pattern_search.rs
+++ b/src/commands/pattern_search.rs
@@ -1,9 +1,11 @@
 use crate::commands::boyer_moore::{BoyerMooreSearch, SearchIn};
 use aho_corasick::AhoCorasick;
+use regex::Regex;
 
 #[derive(Debug, Clone)]
 pub struct PatternTree {
     pub ignore_case: bool,
+    pub regex_flag: bool,
 }
 
 type PatternPosition = (bool, Vec<usize>);
@@ -13,6 +15,7 @@ impl PatternTree {
     pub fn new() -> Self {
         PatternTree {
             ignore_case: false,
+            regex_flag: false,
         }
     }
 
@@ -24,27 +27,27 @@ impl PatternTree {
     /// Whereas, if the pattern is multiple, then call `aho_corasick_search` method.
     /// AC is known as the fastest algorithm for multiple pattern search.
     pub fn selective_search(&self, patterns: &Vec<String>, text: &str) -> PatternPosition {
+        if self.regex_flag {
+            return self.regex(text, &patterns[0]);
+        }
+
         match patterns.len() {
             0 => (false, vec![]),
-            1 => {
-                match self.ignore_case {
-                    true => self.boyer_moore_search(&text.to_lowercase(), &patterns[0].to_lowercase()),
-                    false => self.boyer_moore_search(text, &patterns[0]),
-                }
+            1 => match self.ignore_case {
+                true => self.boyer_moore_search(&text.to_lowercase(), &patterns[0].to_lowercase()),
+                false => self.boyer_moore_search(text, &patterns[0]),
             },
             _ => {
                 if self.ignore_case {
                     let mut lower_patterns: Vec<String> = Vec::new();
-
-                    for pattern in patterns {
-                        lower_patterns.push(pattern.to_lowercase());
-                    }
-
+                    patterns
+                        .iter()
+                        .for_each(|pattern| lower_patterns.push(pattern.to_lowercase()));
                     self.aho_corasick_search(&text.to_lowercase(), &lower_patterns)
                 } else {
                     self.aho_corasick_search(text, patterns)
                 }
-            },
+            }
         }
     }
 
@@ -62,6 +65,21 @@ impl PatternTree {
     pub fn boyer_moore_search(&self, text: &str, pattern: &String) -> PatternPosition {
         let searcher = BoyerMooreSearch::new(pattern.as_bytes());
         let result: Vec<usize> = searcher.find_in(text.as_bytes()).collect();
+
+        (!result.is_empty(), result)
+    }
+
+    pub fn regex(&self, text: &str, pattern: &String) -> PatternPosition {
+        let re = match self.ignore_case {
+            true => Regex::new(&format!(r"(?i){}", pattern)).unwrap(),
+            false => Regex::new(pattern).unwrap(),
+        };
+
+        let mut result: Vec<usize> = Vec::new();
+
+        for matched in re.find_iter(text) {
+            result.push(matched.start());
+        }
 
         (!result.is_empty(), result)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,16 +23,43 @@ enum BalpanCommand {
     Init,
     #[clap(about = "Reset environment for Balpan and removes all TODO comments")]
     Reset,
-    #[clap(about = "Search for TODO comments in the current repository")]
+    #[clap(about = "Searches a particular pattern of characters, and displays all lines that contain that pattern")]
     Grep {
-        #[clap(short, long, help = "Specific file to scan")]
+        #[clap(short = 'f', long, help = "Specific file to scan")]
         file: Option<String>,
-        #[clap(short, long, help = "Specific pattern to search")]
+        #[clap(short = 'p', long, help = "Specific pattern to search")]
         pattern: Option<String>,
         #[clap(
             long,
             help = "Apply formatting to the output. Available options: json, tree, plain (default)"
         )]
+        #[clap(
+            short = 'i',
+            long = "ignore",
+            help = "ignores the case(upper or lower) of the pattern."
+        )]
+        ignore_case: Option<Vec<String>>,
+        #[clap(
+            short = 'H',
+            help = "Display the matched lines, but do not display the filenames."
+        )]
+        hide_path: bool,
+        #[clap(
+            short = 'l',
+            help = "Display the names of files that contain matches, without displaying the matched lines."
+        )]
+        list_of_files: bool,
+        #[clap(
+            short = 'c',
+            help = "This prints only a count of the lines that match a pattern."
+        )]
+        count: bool,
+        #[clap(
+            short = 'T',
+            long = "time",
+            help = "Display the elapsed time during the execution of the command."
+        )]
+        show_elapsed_time: bool,
         format: Option<String>,
     },
 }
@@ -64,6 +91,11 @@ fn main() {
             file,
             pattern,
             format,
+            ignore_case,
+            hide_path,
+            list_of_files,
+            count,
+            show_elapsed_time: elapsed,
         } => {
             let time = Instant::now();
             let runtime = create_runtime();
@@ -73,10 +105,12 @@ fn main() {
 
             runtime.block_on(async {
                 let mut report = GrepReport::new();
-                handle_grep(file, patterns, &mut report, format).await;
+                handle_grep(file, patterns, &mut report, format, ignore_case, hide_path, list_of_files, count).await;
             });
 
-            println!("time: {:?}", time.elapsed());
+            if elapsed {
+                println!("time: {:?}", time.elapsed());
+            }
         }
     }
 }
@@ -170,15 +204,31 @@ async fn handle_init() {
     println!("init!");
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_grep(
     file: Option<String>,
     pattern: Option<Vec<String>>,
     report: &mut GrepReport,
     format: Option<String>,
+    ignore_case: Option<Vec<String>>,
+    hide_path: bool,
+    list_of_files: bool,
+    count: bool,
 ) {
     let mut pattern_tree = PatternTree::new();
     let default_patterns = vec!["[TODO]".to_string(), "[DONE]".to_string()];
-    let patterns_to_search = pattern.unwrap_or(default_patterns);
+
+    let patterns_to_search: Vec<String>;
+
+    match ignore_case {
+        Some(ignore_patterns) => {
+            pattern_tree.ignore_case = true;
+            patterns_to_search = ignore_patterns;
+        }
+        None => {
+            patterns_to_search = pattern.unwrap_or(default_patterns);
+        }
+    }
 
     match file {
         Some(file_path) => {
@@ -187,7 +237,7 @@ async fn handle_grep(
         None => scan_project_directory(report, pattern_tree, patterns_to_search).await,
     }
 
-    let formatting = report.report_formatting(format);
+    let formatting = report.report_formatting(format, hide_path, list_of_files, count);
     println!("{}", formatting);
 }
 


### PR DESCRIPTION
## :star2: What does this PR do?

Created additional commands to grep to handle more complex rules.

For example, the option `-i` is case-insensitive for patterns. `-H` serves to display only the line where the pattern is located, and `-c` serves to display the number of patterns found. Option `-o` is colorize the matching patterns.

Also, can use the `-E` flag to search for patterns using a regex. However, it's slow rather than boyer-moore, so I'd probably encourage users to use it for single files only.

Many other options have been implemented, and these commands can now be combined to make complex behavior easy to use.

## :memo: Links to relevant issues or information

However, it doesn't yet support JSON format, which we'll fix later.

### Relative Issue

#77
